### PR TITLE
Feat: 룰렛 화면 / 룰렛 다이얼로그 변경

### DIFF
--- a/lib/presentation/main/roulette/roulette_screen.dart
+++ b/lib/presentation/main/roulette/roulette_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:animated_widgets/animated_widgets.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:pokedex_clean/app_timer.dart';
 import 'package:pokedex_clean/domain/model/pokemon.dart';
 import 'package:pokedex_clean/domain/model/user_info.dart';
@@ -139,21 +140,16 @@ class _RouletteScreenState extends State<RouletteScreen> with SingleTickerProvid
     showDialog(
       barrierDismissible: false,
       context: context,
-      builder: (_) => AlertDialog(
-        title: Center(child: Text('${pokemon.description.name} 획득!')),
-        content: Image.network(
-          pokemon.imageurl,
-          height: 400,
-          width: 400,
-        ),
-        actions: [
-          TextButton(
-            onPressed: () {
-              Navigator.of(context).pop();
-            },
-            child: const Text("확인"),
+      builder: (_) => GestureDetector(
+        onTap: context.pop,
+        child: AlertDialog(
+          title: Center(child: Text('${pokemon.description.name} 획득!')),
+          content: Image.network(
+            pokemon.imageurl,
+            height: 400,
+            width: 400,
           ),
-        ],
+        ),
       ),
     );
   }

--- a/lib/presentation/main/roulette/roulette_screen.dart
+++ b/lib/presentation/main/roulette/roulette_screen.dart
@@ -46,7 +46,7 @@ class _RouletteScreenState extends State<RouletteScreen> with SingleTickerProvid
           case ShowSnackBar():
             showSnackBar(context, event.message);
           case ShowDialog():
-            _showPokemonDialog(event.pokemon);
+            _showPokemonDialog(event.pokemon, event.exist);
             appTimer.subtractCount();
         }
       });
@@ -137,7 +137,7 @@ class _RouletteScreenState extends State<RouletteScreen> with SingleTickerProvid
     );
   }
 
-  void _showPokemonDialog(Pokemon pokemon) {
+  void _showPokemonDialog(Pokemon pokemon, bool exist) {
     double width = MediaQuery.of(context).size.width;
     showDialog(
       barrierDismissible: false,
@@ -148,10 +148,12 @@ class _RouletteScreenState extends State<RouletteScreen> with SingleTickerProvid
           scrollable: true,
           title: Center(
             child: Text(
-              '${pokemon.description.name} 획득!',
+              exist ? '중복이네요😢\n${pokemon.description.name}'
+              : '🎉 축하합니다 🎉\n${pokemon.description.name} 획득',
               style: const TextStyle(
                 fontWeight: FontWeight.bold,
               ),
+              textAlign: TextAlign.center,
             ),
           ),
           content: Column(

--- a/lib/presentation/main/roulette/roulette_screen.dart
+++ b/lib/presentation/main/roulette/roulette_screen.dart
@@ -9,6 +9,7 @@ import 'package:pokedex_clean/domain/model/user_info.dart';
 import 'package:pokedex_clean/presentation/common/common.dart';
 import 'package:pokedex_clean/presentation/main/roulette/roulette_ui_event.dart';
 import 'package:pokedex_clean/presentation/main/roulette/roulette_view_model.dart';
+import 'package:pokedex_clean/presentation/main/widget/pokemon_id_text_widget.dart';
 import 'package:provider/provider.dart';
 
 class RouletteScreen extends StatefulWidget {
@@ -94,8 +95,6 @@ class _RouletteScreenState extends State<RouletteScreen> with SingleTickerProvid
       ),
       body: Center(
         child: Container(
-          width: double.infinity,
-          height: double.infinity,
           decoration: const BoxDecoration(
             image: DecorationImage(
               image: AssetImage('assets/images/pokeball/grassland.jpg'),
@@ -107,14 +106,16 @@ class _RouletteScreenState extends State<RouletteScreen> with SingleTickerProvid
             child: ScaleTransition(
               scale: animationSize,
               child: GestureDetector(
-                onTap: activeButton
-                    ? () {
-                        if (_animationController.isDismissed || _animationController.isCompleted) {
-                          _animationController.forward(from: 0.0);
-                          viewModel.drawPokemon(widget.pokemonList, widget.userInfo, widget.email);
-                        }
+                onTap: () {
+                      if(!activeButton) {
+                        showSnackBar(context, '남은 포켓볼이 없습니다');
+                        return;
                       }
-                    : null,
+                      if (_animationController.isDismissed || _animationController.isCompleted) {
+                        _animationController.forward(from: 0.0);
+                        viewModel.drawPokemon(widget.pokemonList, widget.userInfo, widget.email);
+                      }
+                  },
                 child: ShakeAnimatedWidget(
                   enabled: appTimer.count >= 1,
                   duration: const Duration(seconds: 2),
@@ -137,17 +138,37 @@ class _RouletteScreenState extends State<RouletteScreen> with SingleTickerProvid
   }
 
   void _showPokemonDialog(Pokemon pokemon) {
+    double width = MediaQuery.of(context).size.width;
     showDialog(
       barrierDismissible: false,
       context: context,
       builder: (_) => GestureDetector(
         onTap: context.pop,
         child: AlertDialog(
-          title: Center(child: Text('${pokemon.description.name} 획득!')),
-          content: Image.network(
-            pokemon.imageurl,
-            height: 400,
-            width: 400,
+          scrollable: true,
+          title: Center(
+            child: Text(
+              '${pokemon.description.name} 획득!',
+              style: const TextStyle(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              PokemonIdTextWidget(
+                id: pokemon.id,
+                gridCrossAxisCount: 1,
+              ),
+              Image.network(
+                pokemon.imageurl,
+                width: width,
+                height: width,
+              ),
+              if (pokemon.description.flavor_text.isNotEmpty)
+                Text(pokemon.description.flavor_text, style: const TextStyle(fontSize: 18))
+            ],
           ),
         ),
       ),

--- a/lib/presentation/main/roulette/roulette_ui_event.dart
+++ b/lib/presentation/main/roulette/roulette_ui_event.dart
@@ -6,5 +6,5 @@ part 'roulette_ui_event.freezed.dart';
 @freezed
 sealed class RouletteUiEvent with _$RouletteUiEvent {
   const factory RouletteUiEvent.showSnackBar(String message) = ShowSnackBar;
-  const factory RouletteUiEvent.showDialog(Pokemon pokemon) = ShowDialog;
+  const factory RouletteUiEvent.showDialog(Pokemon pokemon, bool exist) = ShowDialog;
 }

--- a/lib/presentation/main/roulette/roulette_view_model.dart
+++ b/lib/presentation/main/roulette/roulette_view_model.dart
@@ -25,14 +25,18 @@ class RouletteViewModel extends ChangeNotifier {
   Future<void> drawPokemon(List<Pokemon> pokemonList, UserInfo userInfo, String email) async {
     final Pokemon pokemon = _drawPokemonUseCase.execute(pokemonList);
 
-    userInfo.pokemons.add(pokemon.id);
+    if (userInfo.pokemons.contains(pokemon.id)) {
+      _controller.add(RouletteUiEvent.showDialog(pokemon, true));
+      return;
+    }
 
+    userInfo.pokemons.add(pokemon.id);
     final Result<void> result = await _addAndUpdateUserInfoUseCase.execute(email, userInfo);
 
     result.when(
       success: (data) {
         _controller.add(
-          RouletteUiEvent.showDialog(pokemon),
+          RouletteUiEvent.showDialog(pokemon, false),
         );
       },
       error: (e) => _controller.add(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -65,14 +65,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.11.0"
-  badges:
-    dependency: "direct main"
-    description:
-      name: badges
-      sha256: a7b6bbd60dce418df0db3058b53f9d083c22cdb5132a052145dc267494df0b84
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.2"
   boolean_selector:
     dependency: transitive
     description:


### PR DESCRIPTION
룰렛 화면
- 중복 뽑기 로직 및 UI 변경

룰렛 다이얼로그
- 확인 버튼 제거
- 다이얼로그 전체 영역 터치시 Dismiss 되도록
- 포켓볼 여분 없을 경우 스낵바 표시
- 포켓몬 ID, 설명 표시 추가