### PR TITLE
Feat: New포켓몬 확인 처리

### DIFF
--- a/lib/presentation/main/detail_screen/detail_screen.dart
+++ b/lib/presentation/main/detail_screen/detail_screen.dart
@@ -14,13 +14,11 @@ import 'widget/detail_type_column_widget.dart';
 class DetailScreen extends StatelessWidget {
   final MainState mainState;
   final Pokemon pokemonData;
-  DetailScreen({
+  const DetailScreen({
     super.key,
     required this.pokemonData,
     required this.mainState,
-  }) {
-    pokemonData.setIsNew = false;
-  }
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/presentation/main/main_screen.dart
+++ b/lib/presentation/main/main_screen.dart
@@ -127,7 +127,26 @@ class _MainScreenState extends State<MainScreen> {
               child: Lottie.asset(squirtleJson,
                   width: MediaQuery.of(context).size.width / 2),
             )
-          : MainGridViewWidget(state: state),
+          : MainGridViewWidget(
+              state: state,
+              onTap: (pokemon) async {
+                if (!pokemon.isCollected) {
+                  showSimpleDialog(
+                    context,
+                    title: '안내',
+                    content: '${'?' * pokemon.description.name.length} 은(는) 미보유 상태입니다.',
+                    isVisibleCancelButton: false
+                  );
+                }
+                else {
+                  await context.push('/main/detail', extra: {
+                    'pokemonList': pokemon,
+                    'mainState': state,
+                  });
+                  viewModel.markItemAsSeen(pokemon);
+                }
+              },
+            ),
       floatingActionButton: FloatingActionButton.large(
         backgroundColor: Colors.lightBlueAccent.withOpacity(0.75),
         shape: RoundedRectangleBorder(

--- a/lib/presentation/main/main_view_model.dart
+++ b/lib/presentation/main/main_view_model.dart
@@ -214,4 +214,9 @@ class MainViewModel extends ChangeNotifier {
     notifyListeners();
     sortedByOptionPokemonList();
   }
+
+  void markItemAsSeen(Pokemon pokemon) {
+    state.pokemonListData.firstWhere((element) => element.id == pokemon.id).isNew = false;
+    notifyListeners();
+  }
 }

--- a/lib/presentation/main/widget/main_grid_view_widget.dart
+++ b/lib/presentation/main/widget/main_grid_view_widget.dart
@@ -10,12 +10,14 @@ import 'package:pokedex_clean/presentation/main/widget/third_column_grid_view_wi
 import 'two_column_grid_view_widget.dart';
 
 class MainGridViewWidget extends StatelessWidget {
+  final MainState state;
+  final Function(Pokemon pokemon) onTap;
   const MainGridViewWidget({
     super.key,
     required this.state,
+    required this.onTap,
   });
 
-  final MainState state;
 
   @override
   Widget build(BuildContext context) {
@@ -40,29 +42,24 @@ class MainGridViewWidget extends StatelessWidget {
           itemCount: pokemonList.length,
           itemBuilder: (context, index) {
             return InkWell(
-              onTap: () => pokemonList[index].isCollected
-                  ? context.push('/main/detail', extra: {
-                      'pokemonList': pokemonList[index],
-                      'mainState': state,
-                    })
-                  : showDialog(
-                      context: context,
-                      builder: (BuildContext context) {
-                        return AlertDialog(
-                          title: const Text('안내'),
-                          content: Text(
-                              '${'?' * pokemonList[index].description.name.length} 은(는) 미보유 상태입니다.'),
-                          actions: [
-                            TextButton(
-                              onPressed: () {
-                                Navigator.of(context).pop();
-                              },
-                              child: const Text('확인'),
-                            ),
-                          ],
-                        );
-                      },
-                    ),
+              onTap: () {
+                onTap(pokemonList[index]);
+              },
+              /*onTap: () async {
+                if (!pokemonList[index].isCollected) {
+                  showSimpleDialog(
+                    context,
+                    title: '안내',
+                    content: '${'?' * pokemonList[index].description.name.length} 은(는) 미보유 상태입니다.',
+                  );
+                }
+                else {
+                  await context.push('/main/detail', extra: {
+                    'pokemonList': pokemonList[index],
+                    'mainState': state,
+                  });
+                }
+              },*/
               child: Container(
                 decoration: BoxDecoration(
                   borderRadius: BorderRadius.circular(10.0),


### PR DESCRIPTION
- 디테일 Screen 생성자의 setter 삭제
- 메인 그리드 위젯의 터치 이벤트 메인 콜백으로 이동
- 메인 콜백에서 상태변경 및 새로고침